### PR TITLE
feat(types): add EVM fields to persist on the sdk.Context struct. One stores the latest non-nil error from `ApplyEvmMsg` and the other tracks whether a transaction occurs within `MsgEthereumTx`.

### DIFF
--- a/types/context.go
+++ b/types/context.go
@@ -41,7 +41,12 @@ type Context struct {
 	priority             int64 // The tx priority, only relevant in CheckTx
 	kvGasConfig          storetypes.GasConfig
 	transientKVGasConfig storetypes.GasConfig
+
+	lastErrApplyEvmMsg *evmErrSlot
+	isEvmTx            bool
 }
+
+type evmErrSlot struct{ evmErr error }
 
 // Proposed rename, not done to avoid API breakage
 type Request = Context
@@ -110,6 +115,7 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 		eventManager:         NewEventManager(),
 		kvGasConfig:          storetypes.KVGasConfig(),
 		transientKVGasConfig: storetypes.TransientGasConfig(),
+		lastErrApplyEvmMsg:   &evmErrSlot{},
 	}
 }
 

--- a/types/nibiru.go
+++ b/types/nibiru.go
@@ -1,0 +1,28 @@
+package types
+
+// ----------------------------------------------------------------------------
+// New EVM
+// ----------------------------------------------------------------------------
+
+// keys should be unexported, unique types
+type lastErrApplyEvmMsg struct{}
+
+// Get/Set helpers. Value receiver is fine: it mutates the pointed slot.
+func (c Context) LastErrApplyEvmMsg() error {
+	if c.lastErrApplyEvmMsg == nil {
+		return nil
+	}
+	return c.lastErrApplyEvmMsg.evmErr
+}
+func (c Context) WithLastErrApplyEvmMsg(e error) {
+	if c.lastErrApplyEvmMsg == nil {
+		return
+	}
+	c.lastErrApplyEvmMsg.evmErr = e
+}
+
+func (c Context) IsEvmTx() bool { return c.isEvmTx }
+func (c Context) WithIsEvmTx(isEvmTx bool) Context {
+	c.isEvmTx = isEvmTx
+	return c
+}


### PR DESCRIPTION
Tested locally with the Nibiru blockhain code using a `go.mod` pointed at this branch. 