### PR TITLE
feat(nibiru): context changes for EVM safety, new types for SDB, and wei change events in x/bank

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,102 @@
+# .cursorignore
+#
+# ## .cursorignore Syntax Exmaple
+# It's generally close to .gitignore syntax with. Examples:
+# config.json     # Specific file
+# dist/           # Directory
+# *.log           # File extension
+# **/logs         # Nested directories
+# !app/           # Exclude from ignore (negate)
+#
+# -----------------------------------------------------------------
+
+# Include (!, exclude from ignore) all patterns from .gitignore
+!.gitignore
+
+# Additional patterns specific to Cursor
+.env*
+**/credentials/*
+**/secrets/*
+private/
+confidential/
+
+# Large binary files and datasets
+*.bin
+*.dat
+*.db
+*.sqlite
+*.sqlite3
+
+# Exclude large generated files
+node_modules/
+dist/
+.cache/ 
+
+# -----------------------------------------------------------------
+# Custom nibiru-cosmos
+# -----------------------------------------------------------------
+
+# Remove the fuzz
+*fuzz*
+fuzzing
+fuzzers
+
+# Repo root direcotries to KEEP -> comment out
+
+# baseapp/
+# codec/
+# core/
+# crypto/
+# docs/
+# errors/
+# math/
+# proto/
+# runtime/
+# server/
+# store/
+# types/
+
+# Repo root direcotries to REMOVE
+
+api/
+client/
+contrib/
+depinject/
+fuzz/
+internal/
+orm/
+scripts/
+simapp/
+snapshots/
+std/
+telemetry/
+tests/
+testutil/
+tools/
+tx/
+version/
+
+# Modules to KEEP -> comment out
+
+# x/auth/
+# x/authz/
+# x/bank/
+# x/staking/
+# x/crisis/
+
+# Modules to REMOVE
+
+x/capability/
+x/consensus/
+x/distribution/
+x/evidence/
+x/feegrant/
+x/genutil/
+x/gov/
+x/group/
+x/mint/
+x/nft/
+x/params/
+x/simulation/
+x/slashing/
+x/upgrade/

--- a/orm/internal/testutil/testutil.go
+++ b/orm/internal/testutil/testutil.go
@@ -99,12 +99,12 @@ var TestFieldSpecs = []TestFieldSpec{
 			}).ProtoReflect()
 		}).AsAny(),
 	},
-	{
-		"e",
-		rapid.Transform(rapid.Int32(), func(x int32) protoreflect.EnumNumber {
-			return protoreflect.EnumNumber(x)
-		}).AsAny(),
-	},
+	// {
+	// 	"e",
+	// 	rapid.Transform(rapid.Int32(), func(x int32) protoreflect.EnumNumber {
+	// 		return protoreflect.EnumNumber(x)
+	// 	}).AsAny(),
+	// },
 }
 
 func MakeTestCodec(fname protoreflect.Name, nonTerminal bool) (ormfield.Codec, error) {

--- a/types/context.go
+++ b/types/context.go
@@ -42,8 +42,14 @@ type Context struct {
 	kvGasConfig          storetypes.GasConfig
 	transientKVGasConfig storetypes.GasConfig
 
+	// Holds a reference to the latest non-nil error resulting from apply
+	// EVM, persisting through panics and nested "revert" calls. This
+	// facilitates the propagation of low-level VM errors.
 	lastErrApplyEvmMsg *evmErrSlot
-	isEvmTx            bool
+	// True if the current execution context is an EVM transaction
+	isEvmTx bool
+	// EvmTxHash returns the tx hash of the current Ethereum transaction.
+	evmTxHash [32]byte
 }
 
 type evmErrSlot struct{ evmErr error }
@@ -116,6 +122,7 @@ func NewContext(ms MultiStore, header tmproto.Header, isCheckTx bool, logger log
 		kvGasConfig:          storetypes.KVGasConfig(),
 		transientKVGasConfig: storetypes.TransientGasConfig(),
 		lastErrApplyEvmMsg:   &evmErrSlot{},
+		evmTxHash:            [32]byte{},
 	}
 }
 

--- a/types/nibiru.go
+++ b/types/nibiru.go
@@ -1,28 +1,45 @@
 package types
 
-// ----------------------------------------------------------------------------
+// ---------------------------------------------------------
 // New EVM
-// ----------------------------------------------------------------------------
+// ---------------------------------------------------------
 
-// keys should be unexported, unique types
+// lastErrApplyEvmMsg: Context keys should be unexported, unique types. A named,
+// empty struct is guaranteed to be unique in any Go scope.
 type lastErrApplyEvmMsg struct{}
 
-// Get/Set helpers. Value receiver is fine: it mutates the pointed slot.
+// Holds a reference to the latest non-nil error resulting from apply
+// EVM, persisting through panics and nested "revert" calls. This
+// facilitates the propagation of low-level VM errors.
 func (c Context) LastErrApplyEvmMsg() error {
+	// Get/Set helpers. Value receiver is fine: it mutates the pointed slot.
 	if c.lastErrApplyEvmMsg == nil {
 		return nil
 	}
 	return c.lastErrApplyEvmMsg.evmErr
 }
-func (c Context) WithLastErrApplyEvmMsg(e error) {
+func (c Context) WithLastErrApplyEvmMsg(e error) Context {
 	if c.lastErrApplyEvmMsg == nil {
-		return
+		return c
 	}
 	c.lastErrApplyEvmMsg.evmErr = e
+	return c
 }
 
+// True if the current execution context is an EVM transaction
 func (c Context) IsEvmTx() bool { return c.isEvmTx }
+
+// WithIsEvmTx specifies whether the current execution context is an EVM transaction
 func (c Context) WithIsEvmTx(isEvmTx bool) Context {
 	c.isEvmTx = isEvmTx
+	return c
+}
+
+// EvmTxHash returns the tx hash of the current Ethereum transaction.
+func (c Context) EvmTxHash() [32]byte { return c.evmTxHash }
+
+// WithEvmTxHash sets the tx hash of the current Ethereum transaction.
+func (c Context) WithEvmTxHash(txhash [32]byte) Context {
+	c.evmTxHash = txhash
 	return c
 }

--- a/x/bank/types/events.go
+++ b/x/bank/types/events.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -21,7 +23,48 @@ const (
 	AttributeKeyReceiver = "receiver"
 	AttributeKeyMinter   = "minter"
 	AttributeKeyBurner   = "burner"
+
+	EventTypeWeiChange          = "wei_change"
+	AttributeKeyWeiChangeAddrs  = "wei_change_addrs"
+	AttributeKeyWeiChangeReason = "wei_change_reason"
 )
+
+func weiChangeReasonAttr(reason string) sdk.Attribute {
+	return sdk.NewAttribute(AttributeKeyWeiChangeReason, reason)
+}
+
+var (
+	WeiChangeReason_SendCoins = weiChangeReasonAttr("bank.SendCoins")
+	// InputOutputCoins - uses addCoins, subUnlockedCoins
+	WeiChangeReason_InputOutputCoins = weiChangeReasonAttr("bank.InputOutputCoins")
+
+	// UndelegateCoins - uses addCoins, subUnlockedCoins
+	WeiChangeReason_UndelegateCoins = weiChangeReasonAttr("bank.UndelegateCoins")
+
+	// MintCoins - uses addCoins
+	WeiChangeReason_MintCoins = weiChangeReasonAttr("bank.MintCoins")
+
+	// BurnCoins - uses subUnlockedCoins
+	WeiChangeReason_BurnCoins = weiChangeReasonAttr("bank.BurnCoins")
+
+	// DelegateCoins - uses addCoins, setBalance
+	WeiChangeReason_DelegateCoins = weiChangeReasonAttr("bank.DelegateCoins")
+
+	// AddWei - EVM SDB only
+	WeiChangeReason_AddWei = weiChangeReasonAttr("evm.AddWei")
+
+	// SubWei - EVM SDB only
+	WeiChangeReason_SubWei = weiChangeReasonAttr("evm.SubWei")
+)
+
+func WeiChangeAddrsString(addrs ...string) string {
+	if len(addrs) == 0 {
+		return ""
+	} else if len(addrs) == 1 {
+		return addrs[0]
+	}
+	return strings.Join(addrs, ", ")
+}
 
 // NewCoinSpentEvent constructs a new coin spent sdk.Event
 func NewCoinSpentEvent(spender sdk.AccAddress, amount sdk.Coins) sdk.Event {
@@ -56,5 +99,17 @@ func NewCoinBurnEvent(burner sdk.AccAddress, amount sdk.Coins) sdk.Event {
 		EventTypeCoinBurn,
 		sdk.NewAttribute(AttributeKeyBurner, burner.String()),
 		sdk.NewAttribute(sdk.AttributeKeyAmount, amount.String()),
+	)
+}
+
+// NewEventWeiChange constructs a "wei_change" event.
+func NewEventWeiChange(reason sdk.Attribute, addrs ...string) sdk.Event {
+	return sdk.NewEvent(
+		EventTypeWeiChange,
+		reason,
+		sdk.NewAttribute(
+			AttributeKeyWeiChangeAddrs,
+			WeiChangeAddrsString(addrs...),
+		),
 	)
 }


### PR DESCRIPTION
## Summary
1. feat(nibiru): context changes for EVM safety, new types for SDB, and wei change
events in x/bank
1. feat(types): add EVM fields to persist on the sdk.Context struct. One (#5)
stores the latest non-nil error from `ApplyEvmMsg` and the other tracks whether a
transaction occurs within `MsgEthereumTx`.

## For Release

```
nibiru/v0.47.11-nibiru.5
```
